### PR TITLE
Add execution backends for terminal runtime

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,60 @@
+# Copilot System Prompt: Agent-OS v2025.10
+
+## Preferences
+- Role: Senior multi-agent engineer enforcing Agent-OS production policy.
+- Tone: Concise, technical, audit-ready.
+
+## Instructions
+
+### Global Directives
+- Workflow: clarify scope ➜ plan ➜ cite context ➜ implement ➜ self-review ➜ list follow-ups.
+- Inspect repo before assuming APIs or paths; never fabricate data.
+- Scrub secrets and personal data; recommend secure storage patterns.
+- Call out non-idempotent or risky steps.
+
+### Coding Standards & QA
+| Lang | Style & Docs | Lint/Test | Prohibited |
+| --- | --- | --- | --- |
+| Python | PEP8 + Google docstrings; type hints required | `ruff`, `pytest` | `eval`, `exec`, unchecked `subprocess` |
+| JS/TS | Airbnb, JSDoc for exports | `eslint`, `jest` | `var`, implicit `any`, direct DOM mutation |
+| Shell | POSIX sh; comment complex logic | `shellcheck`, `bats` | `sudo`, destructive `rm`, net exfil |
+| Markdown | Tables + scoped links | `markdownlint` | Bare URLs |
+
+Always add unit tests for new logic, refresh fixtures, and run or justify linters/tests. Note migrations when breaking behavior changes.
+
+### Architecture Alignment
+- Preserve contracts of `core/quantum_router.py`, `core/graph_engine.py`, `core/terminal_engine.py`, `integrations/xbow_scanner.py`, `services/token_optimizer.py`.
+- Route audit events through `db/audit_log.py` or equivalent hook.
+- Maintain color validation and spacetime layout rules (temporal `z`, hashed palette).
+- New integrations must expose async APIs and register cleanly with orchestrators.
+
+### Multi-LLM & Agent Routing
+| Task | Primary | Secondary | Notes |
+| --- | --- | --- | --- |
+| Code gen & fixes | GPT-4o | Claude 3.5 | Enforce typing, structured outputs |
+| Security/refactor | Claude 3.5 | GPT-4o | Provide rationale + diff summary |
+| Large-context/RAG | Gemini 2.5 | Claude 3.5 | Chunk via vector store, cite files |
+| @diego escalation | Manual | — | Pause automation pending approval |
+
+Default to Quantum Router scoring; respect explicit `@agent` overrides but log them. Chain agents plan ➜ implement ➜ test ➜ review.
+
+### Tooling, MCP, ai-shell
+- Tools: `lint`, `test`, `coverage`, `neo4j-admin`, `rag.search`, `xbow.scan`, `token.report`. Invoke via MCP `/tool name {json}` and validate schema.
+- In `ai-shell`, prefer `--dry-run`; flag destructive commands for confirmation.
+- Log tool invocations with timestamp, parameters, and result.
+
+### Memory & Retrieval
+- Short-term: conversation + open buffers; summarize key decisions.
+- Long-term: vector store (`db/vector_store.py`) and audit history; cite file/function/line anchors.
+- Batch related chunks to avoid middle-loss; keep prompts under ~75% of window.
+
+### Debugging & Security
+- Reproduce bugs with minimal case, show trace, explain root cause, then fix.
+- Re-run affected suites; report commands and outcomes.
+- Enforce least privilege, validate inputs, avoid blocking I/O in async paths, flag insecure network calls.
+- Never hardcode secrets; point to vault/secret manager bindings.
+
+### Documentation & Delivery
+- Update README/CHANGELOG or docs when behavior shifts.
+- Provide diff-oriented summary plus manual test checklist.
+- End responses with open risks or TODOs when present.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # agent-os
+
+## Runtime execution utilities
+
+The `core` package now exposes production-ready building blocks for running
+code directly from the Agent-OS terminal interface:
+
+* `core/executor.py` – streams output from subprocesses spawned with PTY
+  support so interactive programs behave exactly like they do in a real
+  terminal. Supports Python, JavaScript/TypeScript, Rust, Go, Bash, Lua,
+  Ruby, and PHP out of the box.
+* `core/shell.py` – maintains a persistent shell session (default `bash`) that
+  keeps environment state between commands, ideal for task runners and
+  long-lived workflows.
+* `core/repl.py` – provides reusable REPL sessions for Python, Node, and Lua
+  so multi-step evaluations can share interpreter state.
+
+All components are asyncio-native, enabling responsive text UIs and agent
+pipelines. Install dependencies with `pip install pexpect` (plus any
+language runtimes you wish to execute).

--- a/core/executor.py
+++ b/core/executor.py
@@ -1,0 +1,237 @@
+"""Language-aware code execution utilities for Agent-OS.
+
+This module provides an asynchronous interface for executing snippets of
+code in a variety of languages. Execution happens inside a pseudo-terminal
+(PTY) so the behaviour mirrors an interactive terminal session. Output is
+streamed back to the caller to support responsive user interfaces.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import pty
+import shlex
+import shutil
+import subprocess
+import tempfile
+from typing import AsyncIterator, Dict, Iterable, List, Optional
+
+
+class LanguageExecutor:
+    """Execute snippets of code across multiple programming languages.
+
+    The executor writes source code to a temporary file and invokes the
+    corresponding interpreter or compiler in a PTY-backed subprocess. Output
+    is streamed in near real time by yielding chunks from an asynchronous
+    generator. A reference to the running process is stored on the instance so
+    callers can send signals (e.g. SIGINT) if required.
+    """
+
+    #: Mapping of language identifiers to the command used for execution.
+    INTERPRETERS: Dict[str, List[str]] = {
+        "python": ["python3", "-u"],
+        "javascript": ["node"],
+        "typescript": ["deno", "run"],
+        "rust": ["rustc"],
+        "go": ["go", "run"],
+        "bash": ["bash"],
+        "lua": ["lua"],
+        "ruby": ["ruby"],
+        "php": ["php"],
+    }
+
+    #: File extensions associated with each supported language.
+    EXTENSIONS: Dict[str, str] = {
+        "python": "py",
+        "javascript": "js",
+        "typescript": "ts",
+        "rust": "rs",
+        "go": "go",
+        "bash": "sh",
+        "lua": "lua",
+        "ruby": "rb",
+        "php": "php",
+    }
+
+    def __init__(self) -> None:
+        self.current_process: Optional[subprocess.Popen[bytes]] = None
+
+    async def execute(
+        self,
+        code: str,
+        language: str,
+        *,
+        stdin: Optional[str] = None,
+        working_directory: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> AsyncIterator[str]:
+        """Execute *code* written in *language* and stream the output.
+
+        Parameters
+        ----------
+        code:
+            Source code to execute.
+        language:
+            Identifier for the interpreter/compiler to use.
+        stdin:
+            Optional standard input that will be sent to the subprocess once it
+            has started.
+        working_directory:
+            Directory from which the command should be executed. Defaults to
+            the current working directory of the Python process.
+        env:
+            Optional environment overrides supplied to ``subprocess.Popen``.
+
+        Yields
+        ------
+        str
+            Chunks of text streamed from the subprocess's stdout/stderr.
+        """
+
+        language = language.lower()
+        if language not in self.INTERPRETERS:
+            yield f"Error: language '{language}' is not supported.\n"
+            return
+
+        command = self._build_command(language)
+        if not self._command_is_available(command):
+            exe = command if isinstance(command, str) else command[0]
+            yield f"Error: interpreter '{exe}' is not available on PATH.\n"
+            return
+
+        # Persist the code to a temporary file for the interpreter to consume.
+        suffix = f".{self.EXTENSIONS.get(language, 'txt')}"
+        fd, temp_path = tempfile.mkstemp(suffix=suffix, text=True)
+        master_fd: Optional[int] = None
+        proc: Optional[subprocess.Popen[bytes]] = None
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(code)
+
+            cmd = self._format_command(command, language, temp_path)
+            master_fd, slave_fd = pty.openpty()
+
+            try:
+                proc = subprocess.Popen(
+                    cmd,
+                    stdin=slave_fd,
+                    stdout=slave_fd,
+                    stderr=slave_fd,
+                    cwd=working_directory or os.getcwd(),
+                    env={**os.environ, **(env or {})},
+                    shell=isinstance(cmd, str),
+                    close_fds=True,
+                )
+            except Exception:
+                os.close(slave_fd)
+                raise
+            os.close(slave_fd)
+            self.current_process = proc
+
+            # Send any provided stdin once the process has started.
+            if stdin:
+                await asyncio.to_thread(os.write, master_fd, stdin.encode("utf-8"))
+
+            try:
+                async for chunk in self._stream_from_fd(master_fd, proc):
+                    yield chunk
+            finally:
+                if proc is not None:
+                    exit_code = proc.poll()
+                    if exit_code is None:
+                        exit_code = await asyncio.to_thread(proc.wait)
+                    yield f"\n[Exit code: {exit_code}]\n"
+        finally:
+            if self.current_process and self.current_process.poll() is None:
+                self.current_process.terminate()
+                try:
+                    await asyncio.to_thread(self.current_process.wait, 2)
+                except Exception:
+                    self.current_process.kill()
+            self.current_process = None
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+            if master_fd is not None:
+                try:
+                    os.close(master_fd)
+                except Exception:
+                    pass
+
+    async def _stream_from_fd(
+        self, master_fd: int, proc: subprocess.Popen[bytes]
+    ) -> AsyncIterator[str]:
+        """Yield decoded chunks from *master_fd* until *proc* exits."""
+
+        while True:
+            if proc.poll() is not None:
+                # Drain any remaining data before exiting the loop.
+                while True:
+                    try:
+                        data = await asyncio.to_thread(os.read, master_fd, 1024)
+                    except OSError:
+                        data = b""
+                    if not data:
+                        return
+                    yield data.decode("utf-8", errors="replace")
+                return
+
+            try:
+                data = await asyncio.wait_for(
+                    asyncio.to_thread(os.read, master_fd, 1024), 0.1
+                )
+            except asyncio.TimeoutError:
+                continue
+            except OSError:
+                data = b""
+
+            if data:
+                yield data.decode("utf-8", errors="replace")
+
+    def _build_command(self, language: str) -> Iterable[str] | str:
+        """Return the base command used to execute *language*."""
+
+        command = self.INTERPRETERS[language]
+        # Return a copy to avoid mutating the class-level mapping.
+        return list(command)
+
+    def _format_command(
+        self, command: Iterable[str] | str, language: str, source_path: str
+    ) -> Iterable[str] | str:
+        """Inject *source_path* into *command* where appropriate."""
+
+        if language == "rust":
+            output_path = self._output_path(source_path)
+            compile_cmd = ["rustc", source_path, "-o", output_path]
+            return f"{self._quote_args(compile_cmd)} && {shlex.quote(output_path)}"
+
+        if isinstance(command, str):
+            return command.format(file=source_path, output=self._output_path(source_path))
+
+        formatted: List[str] = []
+        for part in command:
+            formatted.append(
+                part.format(file=source_path, output=self._output_path(source_path))
+            )
+
+        formatted.append(source_path)
+        return formatted
+
+    def _command_is_available(self, command: Iterable[str] | str) -> bool:
+        if isinstance(command, str):
+            executable = command.split()[0]
+            return shutil.which(executable) is not None
+        return shutil.which(command[0]) is not None
+
+    @staticmethod
+    def _output_path(source_path: str) -> str:
+        base, _ = os.path.splitext(source_path)
+        return base
+
+    @staticmethod
+    def _quote_args(args: Iterable[str]) -> str:
+        return " ".join(shlex.quote(part) for part in args)
+
+
+__all__ = ["LanguageExecutor"]

--- a/core/repl.py
+++ b/core/repl.py
@@ -1,0 +1,83 @@
+"""Language-specific REPL management utilities."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict
+
+import pexpect
+
+
+@dataclass
+class REPLConfig:
+    command: str
+    prompt: str
+
+
+class REPLManager:
+    """Create and manage persistent REPL sessions for multiple languages."""
+
+    SUPPORTED: Dict[str, REPLConfig] = {
+        "python": REPLConfig(command="python3", prompt=">>> "),
+        "node": REPLConfig(command="node", prompt="> "),
+        "lua": REPLConfig(command="lua", prompt="> "),
+    }
+
+    def __init__(self) -> None:
+        self.repls: Dict[str, pexpect.spawn] = {}
+
+    async def get_repl(self, language: str) -> pexpect.spawn:
+        """Return a running REPL for *language*, creating it if needed."""
+
+        language = language.lower()
+        if language not in self.SUPPORTED:
+            raise ValueError(f"No REPL available for language '{language}'")
+
+        if language in self.repls and self.repls[language].isalive():
+            return self.repls[language]
+
+        config = self.SUPPORTED[language]
+        repl = pexpect.spawn(
+            config.command,
+            encoding="utf-8",
+            timeout=None,
+            echo=False,
+        )
+        await asyncio.to_thread(repl.expect_exact, config.prompt)
+        self.repls[language] = repl
+        return repl
+
+    async def eval(self, language: str, code: str) -> str:
+        """Evaluate *code* in the REPL for *language* and return the output."""
+
+        repl = await self.get_repl(language)
+        config = self.SUPPORTED[language]
+
+        await asyncio.to_thread(repl.sendline, code)
+        await asyncio.to_thread(repl.expect_exact, config.prompt)
+        raw = repl.before.replace("\r\n", "\n")
+        return raw.strip()
+
+    def stop(self, language: str | None = None) -> None:
+        """Stop a single REPL or all managed REPLs."""
+
+        if language is None:
+            for repl in list(self.repls.values()):
+                repl.close(force=True)
+            self.repls.clear()
+            return
+
+        lang = language.lower()
+        repl = self.repls.get(lang)
+        if repl is not None:
+            repl.close(force=True)
+            del self.repls[lang]
+
+    def __del__(self) -> None:  # pragma: no cover - defensive cleanup
+        try:
+            self.stop()
+        except Exception:
+            pass
+
+
+__all__ = ["REPLManager", "REPLConfig"]

--- a/core/shell.py
+++ b/core/shell.py
@@ -1,0 +1,93 @@
+"""Persistent interactive shell management for Agent-OS."""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import AsyncIterator, Optional
+
+import pexpect
+
+
+class InteractiveShell:
+    """Maintain a long-running shell session with asynchronous access."""
+
+    def __init__(self, shell_type: str = "bash", prompt: str = "AGENT_OS> ") -> None:
+        self.shell_type = shell_type
+        self.prompt = prompt
+        self.process: Optional[pexpect.spawn] = None
+        self.cwd = os.getcwd()
+
+    async def start(self) -> None:
+        """Spawn the interactive shell if it is not already running."""
+
+        if self.process is not None and self.process.isalive():
+            return
+
+        self.process = pexpect.spawn(
+            self.shell_type,
+            timeout=None,
+            encoding="utf-8",
+            echo=False,
+            cwd=self.cwd,
+        )
+
+        await asyncio.to_thread(self.process.sendline, f'export PS1="{self.prompt}"')
+        await asyncio.to_thread(self.process.expect_exact, self.prompt)
+
+    async def execute(self, command: str) -> AsyncIterator[str]:
+        """Execute *command* within the persistent shell."""
+
+        if self.process is None or not self.process.isalive():
+            await self.start()
+
+        assert self.process is not None
+
+        await asyncio.to_thread(self.process.sendline, command)
+        try:
+            output = await asyncio.to_thread(self._collect_until_prompt)
+        except pexpect.EOF:
+            output = (self.process.before or "").replace("\r\n", "\n")
+            self.stop()
+
+        for chunk in output.splitlines(keepends=True):
+            if chunk:
+                yield chunk
+
+        if self.process is not None:
+            await self._update_cwd()
+
+    async def _update_cwd(self) -> None:
+        if self.process is None or not self.process.isalive():
+            return
+
+        await asyncio.to_thread(self.process.sendline, "pwd")
+        try:
+            await asyncio.to_thread(self.process.expect_exact, self.prompt)
+        except pexpect.EOF:
+            self.stop()
+            return
+        raw = (self.process.before or "").strip()
+        if raw:
+            self.cwd = raw.splitlines()[-1]
+
+    def stop(self) -> None:
+        """Terminate the shell session."""
+
+        if self.process is not None:
+            self.process.close(force=True)
+            self.process = None
+
+    def __del__(self) -> None:  # pragma: no cover - defensive cleanup
+        try:
+            self.stop()
+        except Exception:
+            pass
+
+    def _collect_until_prompt(self) -> str:
+        assert self.process is not None
+        self.process.expect_exact(self.prompt)
+        raw = self.process.before
+        return raw.replace("\r\n", "\n")
+
+
+__all__ = ["InteractiveShell"]


### PR DESCRIPTION
## Summary
- add a PTY-backed LanguageExecutor that streams output from multiple language runtimes
- introduce persistent InteractiveShell and REPLManager helpers for interactive workflows
- document the new runtime execution utilities in the README

## Testing
- python - <<'PY' (LanguageExecutor smoke test)
- python - <<'PY' (InteractiveShell smoke test)
- python - <<'PY' (REPLManager smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68de482f563c832593f70eef1a8d44cf