### PR TITLE
Use select-based streaming for PTY output

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import os
 import pty
+import select
 import shlex
 import shutil
 import subprocess
@@ -175,19 +176,30 @@ class LanguageExecutor:
                     if not data:
                         return
                     yield data.decode("utf-8", errors="replace")
-                return
 
             try:
-                data = await asyncio.wait_for(
-                    asyncio.to_thread(os.read, master_fd, 1024), 0.1
+                ready, _, _ = await asyncio.to_thread(
+                    select.select, [master_fd], [], [], 0.1
                 )
-            except asyncio.TimeoutError:
+            except (OSError, ValueError):
+                ready = []
+
+            if not ready:
                 continue
+
+            try:
+                data = await asyncio.to_thread(os.read, master_fd, 1024)
             except OSError:
                 data = b""
 
             if data:
                 yield data.decode("utf-8", errors="replace")
+            elif proc.poll() is not None:
+                # If the process has finished and the PTY reports EOF we
+                # terminate the stream on the next iteration.
+                continue
+            else:
+                await asyncio.sleep(0)
 
     def _build_command(self, language: str) -> Iterable[str] | str:
         """Return the base command used to execute *language*."""

--- a/tests/test_executor_streaming.py
+++ b/tests/test_executor_streaming.py
@@ -1,0 +1,34 @@
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.executor import LanguageExecutor
+
+
+def test_execute_streams_delayed_output():
+    executor = LanguageExecutor()
+    code = """
+import sys
+import time
+
+sys.stdout.write('first\\n')
+sys.stdout.flush()
+time.sleep(0.3)
+sys.stdout.write('second\\n')
+sys.stdout.flush()
+""".strip()
+
+    async def collect_output() -> str:
+        chunks = []
+        async for chunk in executor.execute(code, "python"):
+            chunks.append(chunk)
+        return "".join(chunks).replace("\r", "")
+
+    output = asyncio.run(collect_output())
+
+    assert "first\n" in output
+    assert "second\n" in output
+    assert output.index("first") < output.index("second")
+    assert "[Exit code: 0]" in output


### PR DESCRIPTION
## Summary
- replace the timeout-based read loop with select-driven reads so PTY output is never cancelled mid-chunk
- keep draining any remaining bytes after process exit while yielding every chunk
- add a regression test that runs a delayed Python script and asserts the full stream is delivered

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de63f6dac483259c40fc725b9d718c